### PR TITLE
Update glibc{-bin} package location and version

### DIFF
--- a/alpine-miniconda/Dockerfile
+++ b/alpine-miniconda/Dockerfile
@@ -21,10 +21,11 @@ RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/re
     libxext \
     libxrender \
     tini@testing \
+    && curl "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" -o /etc/apk/keys/sgerrand.rsa.pub \
     && curl -L "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" -o glibc.apk \
-    && apk add --allow-untrusted glibc.apk \
+    && apk add glibc.apk \
     && curl -L "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-bin-2.23-r3.apk" -o glibc-bin.apk \
-    && apk add --allow-untrusted glibc-bin.apk \
+    && apk add glibc-bin.apk \
     && /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib \
     && rm -rf glibc*apk /var/cache/apk/*
 

--- a/alpine-miniconda/Dockerfile
+++ b/alpine-miniconda/Dockerfile
@@ -66,7 +66,7 @@ USER root
 
 # Configure container startup as root
 WORKDIR /home/$NB_USER/work
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "/bin/bash" ]
 
 # Switch back to jovyan to avoid accidental container runs as root

--- a/alpine-miniconda/Dockerfile
+++ b/alpine-miniconda/Dockerfile
@@ -21,11 +21,11 @@ RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/re
     libxext \
     libxrender \
     tini@testing \
-    && curl "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" -o glibc.apk \
+    && curl -L "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" -o glibc.apk \
     && apk add --allow-untrusted glibc.apk \
-    && curl "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-bin-2.21-r2.apk" -o glibc-bin.apk \
+    && curl -L "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-bin-2.23-r3.apk" -o glibc-bin.apk \
     && apk add --allow-untrusted glibc-bin.apk \
-    && /usr/glibc/usr/bin/ldconfig /lib /usr/glibc/usr/lib \
+    && /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib \
     && rm -rf glibc*apk /var/cache/apk/*
 
 

--- a/alpine-minimal-notebook/Dockerfile
+++ b/alpine-minimal-notebook/Dockerfile
@@ -34,7 +34,7 @@ USER root
 # Configure container startup as root
 EXPOSE 8888
 WORKDIR /home/$NB_USER/work
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["start-notebook.sh"]
 
 # Add local files as late as possible to avoid cache busting


### PR DESCRIPTION
I've made the Dockerfile work again (the previous URLs don't work anymore) and updated the used versions of glibc{-bin} apk packages.
